### PR TITLE
spec-file - Add post-install script to enable user_allow_other

### DIFF
--- a/pkg/rpm/telemetry.spec.in
+++ b/pkg/rpm/telemetry.spec.in
@@ -29,6 +29,12 @@ telemetry data in your program.
 %install
 %cmake_install
 
+%post
+# Add a line to /etc/fuse.conf if it doesn't already exist
+if ! grep -q "^user_allow_other" /etc/fuse.conf; then
+    echo "user_allow_other" >> /etc/fuse.conf
+fi
+
 %files
 %license LICENSE
 %{_libdir}/libtelemetry.so


### PR DESCRIPTION
 - Add post-install script to enable user_allow_other in /etc/fuse.conf
- Added a script to the RPM spec file that checks for the presence of 'user_allow_other' in /etc/fuse.conf.
- If the line is not found, it appends 'user_allow_other' to the file.
- This change ensures that users can allow non-root users to access FUSE filesystems.