### PR TITLE
Telemetry - add symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,16 +104,17 @@ $ cat /tmp/telemetry/*
 ## Advanced Example
 
 The advanced example demonstrates a telemetry data structure that organizes and stores metrics
-from multiple servers located in different data centers.
+from multiple servers located in different data centers, utilizing symbolic links for easier
+access by location and ID.
 
 ### Advanced Example Directory Structure
 After running the advanced example, the resulting directory structure is as follows:
 
 ```bash
-$ tree /tmp/telemetry
-/tmp/telemetry
+$ tree /tmp/telemetry/
+tmp/telemetry/
 └── data_centers
-    ├── new_york
+    ├── 0-prague
     │   ├── server_count
     │   ├── servers
     │   │   ├── server_0
@@ -124,7 +125,7 @@ $ tree /tmp/telemetry
     │   │       └── stats
     │   └── summary
     │       └── summary_stats
-    ├── prague
+    ├── 1-new_york
     │   ├── server_count
     │   ├── servers
     │   │   ├── server_0
@@ -135,17 +136,25 @@ $ tree /tmp/telemetry
     │   │       └── stats
     │   └── summary
     │       └── summary_stats
-    └── tokyo
-        ├── server_count
-        ├── servers
-        │   ├── server_0
-        │   │   └── stats
-        │   ├── server_1
-        │   │   └── stats
-        │   └── server_2
-        │       └── stats
-        └── summary
-            └── summary_stats
+    ├── 2-tokyo
+    │   ├── server_count
+    │   ├── servers
+    │   │   ├── server_0
+    │   │   │   └── stats
+    │   │   ├── server_1
+    │   │   │   └── stats
+    │   │   └── server_2
+    │   │       └── stats
+    │   └── summary
+    │       └── summary_stats
+    ├── by-id
+    │   ├── 0 -> ../0-prague
+    │   ├── 1 -> ../1-new_york
+    │   └── 2 -> ../2-tokyo
+    └── by-location
+        ├── new_york -> ../1-new_york
+        ├── prague -> ../0-prague
+        └── tokyo -> ../2-tokyo
 ```
 
 ### Example Telemetry Output
@@ -153,7 +162,7 @@ Telemetry metrics are stored in files such as stats, which contain real-time dat
 Below is an example of the contents of a stats file for a specific server:
 
 ```bash
-$ cat /tmp/telemetry/data_centers/prague/servers/server_0/stats
+$ cat /tmp/telemetry/data_centers/0-prague/servers/server_0/stats
 cpu_usage:    74.28 (%)
 disk_usage:   13.48 (%)
 latency:      170.20 (ms)
@@ -164,7 +173,7 @@ timestamp:    2024-10-03 15:18:41
 You can also view summary statistics for a data center by reading the summary_stats file:
 
 ```bash
-$ cat /tmp/telemetry/data_centers/prague/summary/summary_stats
+$ cat /tmp/telemetry/data_centers/by-location/prague/summary/summary_stats
 cpu_usage [avg]:    44.20 (%)
 disk_usage [avg]:   35.78 (%)
 latency [avg]:      121.82 (ms)

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,7 @@ This example demonstrates two different telemetry applications: a simple example
 The simple example showcases the basic functionality of the telemetry system, providing essential information
 such as process ID, start time, uptime, and version. The advanced example, on the other hand, offers a more
 comprehensive telemetry data structure that organizes and stores metrics from multiple servers located in
-different data centers.
+different data centers, utilizing symbolic links for easier access by location and ID.
 
 ## Simple Example
 
@@ -42,10 +42,10 @@ telemetry metrics such as CPU usage, memory usage, latency, and disk usage.
 The resulting directory structure after running the advanced example is as follows:
 
 ```bash
-$ tree /tmp/telemetry
-/tmp/telemetry
+$ tree /tmp/telemetry/
+tmp/telemetry/
 └── data_centers
-    ├── new_york
+    ├── 0-prague
     │   ├── server_count
     │   ├── servers
     │   │   ├── server_0
@@ -56,7 +56,7 @@ $ tree /tmp/telemetry
     │   │       └── stats
     │   └── summary
     │       └── summary_stats
-    ├── prague
+    ├── 1-new_york
     │   ├── server_count
     │   ├── servers
     │   │   ├── server_0
@@ -67,17 +67,25 @@ $ tree /tmp/telemetry
     │   │       └── stats
     │   └── summary
     │       └── summary_stats
-    └── tokyo
-        ├── server_count
-        ├── servers
-        │   ├── server_0
-        │   │   └── stats
-        │   ├── server_1
-        │   │   └── stats
-        │   └── server_2
-        │       └── stats
-        └── summary
-            └── summary_stats
+    ├── 2-tokyo
+    │   ├── server_count
+    │   ├── servers
+    │   │   ├── server_0
+    │   │   │   └── stats
+    │   │   ├── server_1
+    │   │   │   └── stats
+    │   │   └── server_2
+    │   │       └── stats
+    │   └── summary
+    │       └── summary_stats
+    ├── by-id
+    │   ├── 0 -> ../0-prague
+    │   ├── 1 -> ../1-new_york
+    │   └── 2 -> ../2-tokyo
+    └── by-location
+        ├── new_york -> ../1-new_york
+        ├── prague -> ../0-prague
+        └── tokyo -> ../2-tokyo
 ```
 
 ### Example of Telemetry Output
@@ -85,7 +93,7 @@ $ tree /tmp/telemetry
 Here is an example of the contents of the `stats` file for a specific server:
 
 ```bash
-$ cat /tmp/telemetry/data_centers/prague/servers/server_0/stats
+$ cat /tmp/telemetry/data_centers/0-prague/servers/server_0/stats
 cpu_usage:    74.28 (%)
 disk_usage:   13.48 (%)
 latency:      170.20 (ms)
@@ -96,7 +104,7 @@ timestamp:    2024-10-03 15:18:41
 Example of the contents of the `summary_stats` file for a data center:
 
 ```bash
-$ cat /tmp/telemetry/data_centers/prague/summary/summary_stats
+$ cat /tmp/telemetry/data_centers/by-location/prague/summary/summary_stats
 cpu_usage [avg]:    44.20 (%)
 disk_usage [avg]:   35.78 (%)
 latency [avg]:      121.82 (ms)

--- a/examples/advanced/dataCenter.cpp
+++ b/examples/advanced/dataCenter.cpp
@@ -43,10 +43,15 @@ static std::shared_ptr<telemetry::AggregatedFile> createSummaryFile(
 	return dir->addAggFile(filename, filePattern, aggOps, patternRootDir);
 }
 
-DataCenter::DataCenter(std::string location, std::shared_ptr<telemetry::Directory>& dataCenterDir)
+DataCenter::DataCenter(
+	std::string location,
+	uint64_t dataCenterId,
+	std::shared_ptr<telemetry::Directory>& dataCenterDir)
 	: m_rootDir(dataCenterDir)
 	, m_location(std::move(location))
+	, m_dataCenterId(dataCenterId)
 {
+	(void) m_dataCenterId;
 	setupTelemetry(dataCenterDir);
 }
 

--- a/examples/advanced/dataCenter.hpp
+++ b/examples/advanced/dataCenter.hpp
@@ -40,7 +40,15 @@ public:
 	 * @param location The physical location of the data center.
 	 * @param dataCenterDir Shared pointer to the telemetry directory for this data center.
 	 */
-	DataCenter(std::string location, std::shared_ptr<telemetry::Directory>& dataCenterDir);
+	DataCenter(
+		std::string location,
+		uint64_t dataCenterId,
+		std::shared_ptr<telemetry::Directory>& dataCenterDir);
+
+	DataCenter(const DataCenter& other) = delete;
+	DataCenter& operator=(const DataCenter& other) = delete;
+	DataCenter(DataCenter&& other) = default;
+	DataCenter& operator=(DataCenter&& other) = default;
 
 	/**
 	 * @brief Adds a server to the data center.
@@ -58,6 +66,7 @@ private:
 	std::shared_ptr<telemetry::Directory>
 		m_rootDir; ///< Pointer to the root data center telemetry directory.
 	std::string m_location; ///< The location of the data center.
+	uint64_t m_dataCenterId; ///< The unique identifier of the data center.
 	telemetry::Holder m_holder; ///< Holder for managing telemetry files.
 	std::vector<Server> m_servers; ///< Vector to store added servers.
 };

--- a/include/telemetry/directory.hpp
+++ b/include/telemetry/directory.hpp
@@ -1,6 +1,7 @@
 /**
  * @file
  * @author Lukas Hutak <hutak@cesnet.cz>
+ * @author Pavel Siska <siska@cesnet.cz>
  * @brief Telemetry directory
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -11,6 +12,7 @@
 #include "aggFile.hpp"
 #include "file.hpp"
 #include "node.hpp"
+#include "symlink.hpp"
 
 #include <map>
 #include <memory>
@@ -58,6 +60,27 @@ public:
 	 * @throw TelemetryException if there is already a file with the same name.
 	 */
 	[[nodiscard]] std::shared_ptr<Directory> addDir(std::string_view name);
+
+	/**
+	 * @brief Add a symbolic link.
+	 *
+	 * This function creates a symbolic link with the specified @p name that points to the
+	 * target node specified by @p target. If a node with the same name already exists an exception
+	 * will be thrown.
+	 *
+	 * @param name Name of the symbolic link to be created.
+	 * @param target A shared pointer to the target node (file or directory) that the symlink will
+	 * point to.
+	 * @return A shared pointer to the newly created symbolic link.
+	 *
+	 * @note The directory only holds a weak pointer to the symbolic link, so if the returned
+	 * pointer ceases to exist, the entry will be removed, and it can be replaced with a new one.
+	 *
+	 * @throw TelemetryException If a node with the same name already exists in the
+	 * directory.
+	 */
+	[[nodiscard]] std::shared_ptr<Symlink>
+	addSymlink(std::string_view name, const std::shared_ptr<Node>& target);
 
 	/**
 	 * @brief Add multiple subdirectories with the given @p name.

--- a/include/telemetry/symlink.hpp
+++ b/include/telemetry/symlink.hpp
@@ -1,0 +1,73 @@
+/**
+ * @file
+ * @author Pavel Siska <siska@cesnet.cz>
+ * @brief Defines the Symlink class for representing symbolic links in the telemetry filesystem.
+ *
+ * This file contains the declaration of the Symlink class, which represents a symbolic link node
+ * in the telemetry filesystem. A symbolic link is a special type of node that points to another
+ * node (either a file or directory) and enables indirect access to it.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#pragma once
+
+#include "node.hpp"
+
+#include <memory>
+#include <string_view>
+
+namespace telemetry {
+
+/**
+ * @brief Represents a symbolic link in the telemetry filesystem.
+ *
+ * The Symlink class models a symbolic link (symlink) within the telemetry filesystem. A symlink
+ * is a node that refers to another node (target), which can either be a file or a directory.
+ * It enables transparent access to the target node by redirecting file system operations
+ * through the symlink.
+ */
+class Symlink : public Node {
+public:
+	~Symlink() override = default;
+
+	Symlink(const Symlink& other) = delete;
+	Symlink& operator=(const Symlink& other) = delete;
+	Symlink(Symlink&& other) = delete;
+	Symlink& operator=(Symlink&& other) = delete;
+
+	/**
+	 * @brief Retrieves the target node that the symlink points to.
+	 *
+	 * This method returns a shared pointer to the node that the symlink is referencing. If the
+	 * target node is no longer available, the method will return `nullptr`.
+	 *
+	 * @return A shared pointer to the target node, or nullptr if the target is no longer valid.
+	 */
+	std::shared_ptr<Node> getTarget() const;
+
+private:
+	/**
+	 * @brief Constructs a Symlink object.
+	 *
+	 * The constructor is private and can only be called by the `Directory` class (via friend
+	 * relationship), ensuring that symbolic links can only be created from within a directory
+	 * context. It initializes the symbolic link with a reference to the parent directory, the name
+	 * of the symlink, and the target node to which the symlink points.
+	 *
+	 * @param parent The parent node, which is typically a directory, where the symlink resides.
+	 * @param name The name of the symbolic link.
+	 * @param target The target node (file or directory) that the symlink points to.
+	 */
+	Symlink(
+		const std::shared_ptr<Node>& parent,
+		std::string_view name,
+		const std::shared_ptr<Node>& target);
+
+	std::weak_ptr<Node> m_target;
+
+	// Directory class can create Symlink objects.
+	friend class Directory;
+};
+
+} // namespace telemetry

--- a/include/telemetry/utility.hpp
+++ b/include/telemetry/utility.hpp
@@ -48,6 +48,13 @@ bool isFile(const std::shared_ptr<Node>& node) noexcept;
 bool isDirectory(const std::shared_ptr<Node>& node) noexcept;
 
 /**
+ * @brief Check if a node represents a symlink.
+ * @param node The node to check.
+ * @return True if the node is a symlink, false otherwise.
+ */
+bool isSymlink(const std::shared_ptr<Node>& node) noexcept;
+
+/**
  * @brief Check if a given path is the root directory.
  * @param path The path to check.
  * @return True if the path is the root directory, false otherwise.

--- a/src/telemetry/CMakeLists.txt
+++ b/src/telemetry/CMakeLists.txt
@@ -6,6 +6,7 @@ list(APPEND TELEMETRY_SOURCE_FILES
 	holder.cpp
 	utility.cpp
 	aggFile.cpp
+	symlink.cpp
 	aggregator/aggMethod.cpp
 	aggregator/aggSum.cpp
 	aggregator/aggAvg.cpp

--- a/src/telemetry/directory.cpp
+++ b/src/telemetry/directory.cpp
@@ -1,6 +1,7 @@
 /**
  * @file
  * @author Lukas Hutak <hutak@cesnet.cz>
+ * @author Pavel Siska <siska@cesnet.cz>
  * @brief Telemetry directory
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -96,6 +97,22 @@ std::shared_ptr<AggregatedFile> Directory::addAggFile(
 
 	addEntryLocked(newFile);
 	return newFile;
+}
+
+std::shared_ptr<Symlink>
+Directory::addSymlink(std::string_view name, const std::shared_ptr<Node>& target)
+{
+	const std::lock_guard lock(getMutex());
+	const std::shared_ptr<Node> entry = getEntryLocked(name);
+
+	if (entry != nullptr) {
+		throwEntryAlreadyExists(name);
+	}
+
+	auto newSymlink = std::shared_ptr<Symlink>(new Symlink(shared_from_this(), name, target));
+
+	addEntryLocked(newSymlink);
+	return newSymlink;
 }
 
 std::vector<std::string> Directory::listEntries()

--- a/src/telemetry/symlink.cpp
+++ b/src/telemetry/symlink.cpp
@@ -29,3 +29,7 @@ Symlink::Symlink(
 }
 
 } // namespace telemetry
+
+#ifdef TELEMETRY_ENABLE_TESTS
+#include "tests/testSymlink.cpp"
+#endif

--- a/src/telemetry/symlink.cpp
+++ b/src/telemetry/symlink.cpp
@@ -1,0 +1,31 @@
+/**
+ * @file
+ * @author Pavel Siska <siska@cesnet.cz>
+ * @brief Defines the Symlink class for representing symbolic links in the telemetry filesystem.
+ *
+ * This file contains the declaration of the Symlink class, which represents a symbolic link node
+ * in the telemetry filesystem. A symbolic link is a special type of node that points to another
+ * node (either a file or directory) and enables indirect access to it.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <telemetry/symlink.hpp>
+
+namespace telemetry {
+
+std::shared_ptr<Node> Symlink::getTarget() const
+{
+	return m_target.lock();
+}
+
+Symlink::Symlink(
+	const std::shared_ptr<Node>& parent,
+	std::string_view name,
+	const std::shared_ptr<Node>& target)
+	: Node(parent, name)
+	, m_target(target)
+{
+}
+
+} // namespace telemetry

--- a/src/telemetry/tests/testDirectory.cpp
+++ b/src/telemetry/tests/testDirectory.cpp
@@ -327,4 +327,32 @@ TEST(TelemetryDirectory, getEntryRemoved)
 	EXPECT_EQ(nullptr, root->getEntry("app"));
 }
 
+/**
+ * @test Test creating telemetry symlink.
+ */
+TEST(TelemetryDirectory, addSymlink)
+{
+	auto root = Directory::create();
+
+	auto info = root->addDir("info");
+	auto symlink = root->addSymlink("link", info);
+
+	EXPECT_EQ("link", symlink->getName());
+	EXPECT_EQ("/link", symlink->getFullPath());
+	EXPECT_EQ(info, symlink->getTarget());
+
+	EXPECT_THROW((void) root->addSymlink("link", info), TelemetryException);
+	EXPECT_THROW((void) root->addSymlink("info", info), TelemetryException);
+
+	auto symlinkToSymlink = root->addSymlink("linkToLink", symlink);
+
+	EXPECT_EQ("linkToLink", symlinkToSymlink->getName());
+	EXPECT_EQ("/linkToLink", symlinkToSymlink->getFullPath());
+	EXPECT_EQ(symlink, symlinkToSymlink->getTarget());
+
+	auto targetOfSymlinkToSymlink
+		= std::dynamic_pointer_cast<Symlink>(symlinkToSymlink->getTarget())->getTarget();
+	EXPECT_EQ(info, targetOfSymlinkToSymlink);
+}
+
 } // namespace telemetry

--- a/src/telemetry/tests/testSymlink.cpp
+++ b/src/telemetry/tests/testSymlink.cpp
@@ -1,0 +1,52 @@
+/**
+ * @file
+ * @author Pavel Siska <siska@cesnet.cz>
+ * @brief Unit tests of telemetry::File class
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <telemetry/directory.hpp>
+
+#include <gtest/gtest.h>
+
+namespace telemetry {
+
+/**
+ * @test Test checking symlink target
+ */
+TEST(TelemetrySymlink, hasTarget)
+{
+	auto root = Directory::create();
+	auto dir = root->addDir("dir");
+	auto file = dir->addFile("file", {});
+	auto symlink = root->addSymlink("symlink", file);
+
+	auto target = symlink->getTarget();
+
+	EXPECT_EQ(file, target);
+}
+
+/**
+ * @test Test checking symlink target lifetime
+ */
+TEST(TelemetrySymlink, targetScopeLifetime)
+{
+	auto root = Directory::create();
+	auto dir = root->addDir("dir");
+
+	std::shared_ptr<Symlink> symlink;
+
+	{
+		auto file = dir->addFile("file", {});
+		symlink = root->addSymlink("symlink", file);
+
+		auto target = symlink->getTarget();
+		EXPECT_EQ(file, target);
+	}
+
+	auto target = symlink->getTarget();
+	EXPECT_EQ(nullptr, target);
+}
+
+} // namespace telemetry

--- a/src/telemetry/tests/testUtility.cpp
+++ b/src/telemetry/tests/testUtility.cpp
@@ -86,6 +86,22 @@ TEST(TelemetryUtility, getNodeFromPath)
 /**
  * @test Test checking if the node is a file
  */
+TEST(TelemetryUtility, isSymlink)
+{
+	auto root = Directory::create();
+	auto dir = root->addDir("dir");
+	auto file = dir->addFile("file", {});
+	auto symlink = root->addSymlink("symlink", file);
+
+	EXPECT_FALSE(utils::isSymlink(dir));
+	EXPECT_FALSE(utils::isSymlink(root));
+
+	EXPECT_TRUE(utils::isSymlink(symlink));
+}
+
+/**
+ * @test Test checking if the node is a file
+ */
 TEST(TelemetryUtility, isFile)
 {
 	auto root = Directory::create();

--- a/src/telemetry/utility.cpp
+++ b/src/telemetry/utility.cpp
@@ -11,6 +11,7 @@
 #include <sstream>
 #include <telemetry/directory.hpp>
 #include <telemetry/file.hpp>
+#include <telemetry/symlink.hpp>
 
 namespace telemetry::utils {
 
@@ -70,6 +71,11 @@ bool isFile(const std::shared_ptr<Node>& node) noexcept
 bool isDirectory(const std::shared_ptr<Node>& node) noexcept
 {
 	return std::dynamic_pointer_cast<Directory>(node) != nullptr;
+}
+
+bool isSymlink(const std::shared_ptr<Node>& node) noexcept
+{
+	return std::dynamic_pointer_cast<Symlink>(node) != nullptr;
 }
 
 bool isRootDirectory(const std::string& path) noexcept


### PR DESCRIPTION
- Telemetry - add symbolic link that is a special type of node that points to another node (either a file or directory) and enables indirect access to it.
- AppFs - add support to read symlink
- Add unit tests of symlink 
- Update README
- Update advance example