### PR TITLE
CMake - set default TELEMETRY_PACKAGE_BUILDER to OFF

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,9 @@ jobs:
     - name: make
       run: make
     - name: make rpm
-      run: make rpm
+      run: |
+        cmake -B build -DTELEMETRY_PACKAGE_BUILDER=ON 
+        make rpm
     - name: make examples
       run: make examples
     - name: make install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ include(cmake/installation.cmake)
 include(cmake/dependencies.cmake)
 
 option(TELEMETRY_BUILD_SHARED       "Build shared library" ON)
-option(TELEMETRY_PACKAGE_BUILDER    "Enable RPM package builder (make rpm)" ON)
+option(TELEMETRY_PACKAGE_BUILDER    "Enable RPM package builder (make rpm)" OFF)
 option(TELEMETRY_INSTALL_TARGETS    "Generate the install target" ON)
 option(TELEMETRY_ENABLE_TESTS       "Build Unit tests (make test)" OFF)
 option(TELEMETRY_ENABLE_DOC_DOXYGEN "Enable build of code documentation" OFF)
@@ -43,5 +43,3 @@ endif()
 if (TELEMETRY_PACKAGE_BUILDER)
 	add_subdirectory(pkg)
 endif()
-
-

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ If you prefer to create an RPM package for installation:
 ```bash
 $ git clone https://github.com/CESNET/telemetry.git
 $ cd telemetry
+$ mkdir build && cd build
+$ cmake .. -DTELEMETRY_PACKAGE_BUILDER=ON
 $ make rpm
 ```
 

--- a/include/telemetry/aggMethod.hpp
+++ b/include/telemetry/aggMethod.hpp
@@ -26,7 +26,7 @@ namespace telemetry {
  * - @p JOIN: Scalar value (array included), [bool, uint64_t, int64_t, double, string,
  * std::monostate()]
  */
-enum class AggMethodType { AVG, SUM, MIN, MAX, JOIN };
+enum class AggMethodType : uint8_t { AVG, SUM, MIN, MAX, JOIN };
 
 /**
  * @brief Structure representing an aggregation operation

--- a/src/appFs/appFs.cpp
+++ b/src/appFs/appFs.cpp
@@ -38,7 +38,7 @@ static off_t getMaxFileSize(const std::shared_ptr<File>& file)
 		static_cast<double>(blockSize) * requiredBlockEmptyCapacityMultiplier);
 
 	const size_t contentSize = fileContentToString(file).size();
-	const size_t blockSizeMultiplier = (contentSize + requiredCapacity) / blockSize + 1;
+	const size_t blockSizeMultiplier = ((contentSize + requiredCapacity) / blockSize) + 1;
 
 	return static_cast<off_t>(blockSizeMultiplier * blockSize);
 }
@@ -79,7 +79,7 @@ static void setDirectoryAttr(struct stat* stbuf)
 	stbuf->st_mtime = time(nullptr);
 }
 
-std::shared_ptr<Directory> getRootDirectory()
+static std::shared_ptr<Directory> getRootDirectory()
 {
 	return *reinterpret_cast<std::shared_ptr<Directory>*>(fuse_get_context()->private_data);
 }


### PR DESCRIPTION
### Summary

This PR updates the RPM build process so that TELEMETRY_PACKAGE_BUILDER is explicitly enabled only in CI and when requested by users, instead of being enabled by default.